### PR TITLE
Fixed error in Presence tracking

### DIFF
--- a/apps/stygian_web/lib/stygian_web/presence.ex
+++ b/apps/stygian_web/lib/stygian_web/presence.ex
@@ -16,7 +16,9 @@ defmodule StygianWeb.Presence do
   @doc """
   Tracks the user around the map pages.
   """
-  def track_user(pid, user, character, map \\ nil, is_chat \\ false) do
+  def track_user(pid, user, character, map \\ nil, is_chat \\ false)
+
+  def track_user(pid, user, character, map, is_chat) when is_map(character) do
     %{id: character_id} = character = Map.put(character, :user, user)
 
     Presence.track(
@@ -29,6 +31,8 @@ defmodule StygianWeb.Presence do
       }
     )
   end
+
+  def track_user(_, _, _, _, _), do: {:error, "No character created."}
 
   def list_users do
     Presence.list(@user_activity_topic)


### PR DESCRIPTION
Added a clause for the tracking function to exclude the user from tracking in case they don't have the character created already.