### PR TITLE
Fixed mail configuration

### DIFF
--- a/.github/workflows/push-image-to-act.yml
+++ b/.github/workflows/push-image-to-act.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [ main ]
 
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,6 +21,7 @@ jobs:
           image: stygian
           git_access_token: ${{ secrets.GITHUB_TOKEN }}
           branch: main
+          build_args: '[{"MAIL_PASS": "${{ secrets.MAIL_PASS }}"}]'
 
       # - name: Update Docker Compose
       #   uses: appleboy/ssh-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM hexpm/elixir:1.15.5-erlang-25.2.3-debian-bullseye-20230612-slim as builder
 
+# Setting the SMTP password
+ARG MAIL_PASS  
+
 # install build dependencies
 RUN apt-get update -y && apt-get install -y build-essential git npm \
     && apt-get clean && rm -f /var/lib/apt/lists/*_*
@@ -13,6 +16,7 @@ RUN mix local.hex --force && \
 
 # set build ENV
 ENV MIX_ENV="prod"
+ENV MAIL_PASS=${MAIL_PASS}
 
 # install mix dependencies
 COPY mix.exs mix.lock ./

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -65,6 +65,7 @@ config :stygian_web, StygianWeb.Endpoint,
 # Email settings
 config :stygian, Stygian.Mailer,
   adapter: Swoosh.Adapters.SMTP,
+  ssl: false,
   relay: System.get_env("MAIL_HOST"),
   port: System.get_env("MAIL_PORT"),
   username: System.get_env("MAIL_USER"),

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -20,3 +20,12 @@ config :logger, level: :info
 
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.
+
+# Email settings
+config :stygian, Stygian.Mailer,
+  adapter: Swoosh.Adapters.SMTP,
+  ssl: false,
+  relay: "smtp.stygian.eu",
+  port: 587,
+  username: "postmaster@stygian.eu",
+  password: System.get_env("MAIL_PASS")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -110,12 +110,4 @@ if config_env() == :prod do
   #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
   #
   # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
-
-  # Email settings
-  config :stygian, Stygian.Mailer,
-    adapter: Swoosh.Adapters.SMTP,
-    relay: System.get_env("MAIL_HOST"),
-    port: System.get_env("MAIL_PORT"),
-    username: System.get_env("MAIL_USER"),
-    password: System.get_env("MAIL_PASS")
 end


### PR DESCRIPTION
The problem was that the mail configuration was determined at runtime with environment variable, and the application deployed with docker-compose didn't get that for some reason.

This PR moves the mail configuration to be determined during compilation, so the GitHub Action that builds the Docker image will send the configuration stored as a GitHub Action secret. It disables SSL as well, as the email provider certificate is not recognised by the Erlang CA package.