### PR TITLE
Added automatic status update for NPC

### DIFF
--- a/apps/stygian/lib/stygian/characters.ex
+++ b/apps/stygian/lib/stygian/characters.ex
@@ -292,7 +292,9 @@ defmodule Stygian.Characters do
       |> Repo.insert()
 
     with {:ok, %Character{id: character_id}} <- character,
-         {:ok, _} <- create_character_skills_internal(skills, character_id) do
+         {:ok, _} <- create_character_skills_internal(skills, character_id),
+         character <- get_character!(character_id),
+         {:ok, _} <- complete_character(character) do
       {:ok, character}
     end
   end

--- a/apps/stygian/test/stygian/characters_test.exs
+++ b/apps/stygian/test/stygian/characters_test.exs
@@ -418,8 +418,10 @@ defmodule Stygian.CharactersTest do
       ]
 
       assert {:ok, _} = Characters.create_npc(valid_character, skills)
-      assert [npcs] = Characters.list_npcs()
-      assert "some_name" == npcs.name
+      assert [npc] = Characters.list_npcs()
+      assert "some_name" == npc.name
+      refute is_nil(npc.health)
+      refute is_nil(npc.sanity)
     end
 
     test "update_character_skill/1 correctly updates the character skill" do


### PR DESCRIPTION
The problem was previously solved on another PR, but the real problem was that NPC creation function didn't update the status. This functionality has been added now.