### PR TITLE
Added a check for the input

### DIFF
--- a/apps/stygian_web/assets/js/hooks/chat-hooks.js
+++ b/apps/stygian_web/assets/js/hooks/chat-hooks.js
@@ -16,7 +16,8 @@ export function addChatHooks(Hooks) {
     mounted() {
       this.el.focus()
       this.el.onkeydown = (e) => {
-        if (e.key === "Enter") {
+        // If the value is not greater than 200 the textarea can't dispatch the event
+        if (e.key === "Enter" && this.el.value.length >= 200) {
           // Dispatching the event, that will bubble up to the form
           const event = new Event("submit", { bubbles: true, cancelable: true })
           this.el.form.dispatchEvent(event)


### PR DESCRIPTION
Added a check to the JavaScript hook that controls the chat input to be sent: now the event will be triggered only if the length of the textarea value will be more than 200